### PR TITLE
[Feat] LoginView에서 SimpleOnboardingView로 이동할 수 있는 버튼과 관련 기능 추가 및 디버깅

### DIFF
--- a/Harmony/Harmony.xcodeproj/project.pbxproj
+++ b/Harmony/Harmony.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		BE884B752C5EF2B900D9BCCA /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE884B742C5EF2B900D9BCCA /* FileManager+Extensions.swift */; };
 		BE884B772C5EFCCE00D9BCCA /* MemoryCardChatHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE884B762C5EFCCE00D9BCCA /* MemoryCardChatHistoryView.swift */; };
 		BE884B792C5F91C400D9BCCA /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE884B782C5F91C400D9BCCA /* Array+Extensions.swift */; };
+		BE9332432CF5F1D800A9BE94 /* LoginView+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9332422CF5F1D400A9BE94 /* LoginView+Debug.swift */; };
 		BE96B7E72C473337003C41F9 /* FormatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE96B7E62C473337003C41F9 /* FormatManager.swift */; };
 		BE96B7E92C477FAF003C41F9 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE96B7E82C477FAF003C41F9 /* SearchBarView.swift */; };
 		BE96B7EB2C478040003C41F9 /* UIApplication+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE96B7EA2C478040003C41F9 /* UIApplication+Extensions.swift */; };
@@ -178,6 +179,7 @@
 		BE884B742C5EF2B900D9BCCA /* FileManager+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
 		BE884B762C5EFCCE00D9BCCA /* MemoryCardChatHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryCardChatHistoryView.swift; sourceTree = "<group>"; };
 		BE884B782C5F91C400D9BCCA /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
+		BE9332422CF5F1D400A9BE94 /* LoginView+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginView+Debug.swift"; sourceTree = "<group>"; };
 		BE96B7E62C473337003C41F9 /* FormatManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatManager.swift; sourceTree = "<group>"; };
 		BE96B7E82C477FAF003C41F9 /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
 		BE96B7EA2C478040003C41F9 /* UIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extensions.swift"; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 		55A10B242C4FB97A001728EF /* Auth */ = {
 			isa = PBXGroup;
 			children = (
+				BE9332422CF5F1D400A9BE94 /* LoginView+Debug.swift */,
 				55A10B1F2C4F76C5001728EF /* LoginView.swift */,
 				55A6D3BF2C6A56B400627DD2 /* AppleSignInButton.swift */,
 			);
@@ -656,6 +659,7 @@
 				BE884B732C5EF07A00D9BCCA /* AudioPlayerManager.swift in Sources */,
 				3EA6EBB62C50A1B900627C63 /* CameraView.swift in Sources */,
 				3EE527952C51F9A400B16DB8 /* RoutineReactionInputView.swift in Sources */,
+				BE9332432CF5F1D800A9BE94 /* LoginView+Debug.swift in Sources */,
 				3EA6EBA12C4F489F00627C63 /* CustomTabBar.swift in Sources */,
 				3EA6EBA32C4F492900627C63 /* MainTabView.swift in Sources */,
 				3EA6EBAA2C4F724200627C63 /* RoutineModel.swift in Sources */,

--- a/Harmony/Harmony/ContentView.swift
+++ b/Harmony/Harmony/ContentView.swift
@@ -11,42 +11,67 @@ struct ContentView: View {
     @StateObject var authViewModel = AuthViewModel()
     @StateObject var onboardingViewModel = OnboardingViewModel()
     
+    @EnvironmentObject var memoryCardViewModel: MemoryCardViewModel
+    
     var body: some View {
-        if onboardingViewModel.isOnboardingEnd && authViewModel.isLoggedIn  {
-            MainTabView()
-        } else if authViewModel.isLoggedIn && !onboardingViewModel.isOnboardingEnd {
-            NavigationStack(path: $onboardingViewModel.navigationPath) {
-                AllowNotificationView(viewModel: onboardingViewModel)
-                    .navigationDestination(for: NavigationDestination.self) { destination in
-                        switch destination {
-                        case .createGroup:
-                            CreateGroupSpaceView(viewModel: onboardingViewModel)
-                        case .inputVIPInfo:
-                            InputVIPInfoView(viewModel: onboardingViewModel)
-                            
-                        case .inputUserInfo:
-                            InputUserInfoView(viewModel: onboardingViewModel)
-                            
-                        case .inviteVIP:
-                            InviteVIPView(viewModel: onboardingViewModel)
-                            
-                        case .registerProfile:
-                            RegisterProfileView(viewModel: onboardingViewModel)
-                            
-                        case .joinGroup:
-                            JoinGroupSpaceView(viewModel: onboardingViewModel)
-                            
-                        case .enterGroup:
-                            EnterGroupSpaceView(viewModel: onboardingViewModel)
-                            
+        NavigationStack(path: $onboardingViewModel.navigationPath) {
+            Group {
+                if onboardingViewModel.isOnboardingEnd && authViewModel.isLoggedIn {
+                    MainTabView()
+                        .environmentObject(authViewModel)
+                        .environmentObject(memoryCardViewModel)
+                } else if authViewModel.isLoggedIn && !onboardingViewModel.isOnboardingEnd {
+                    AllowNotificationView(viewModel: onboardingViewModel)
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            switch destination {
+                                case .createGroup:
+                                    CreateGroupSpaceView(viewModel: onboardingViewModel)
+                                    
+                                case .inputVIPInfo:
+                                    InputVIPInfoView(viewModel: onboardingViewModel)
+                                    
+                                case .inputUserInfo:
+                                    InputUserInfoView(viewModel: onboardingViewModel)
+                                    
+                                case .inviteVIP:
+                                    InviteVIPView(viewModel: onboardingViewModel)
+                                    
+                                case .registerProfile:
+                                    RegisterProfileView(viewModel: onboardingViewModel)
+                                    
+                                case .joinGroup:
+                                    JoinGroupSpaceView(viewModel: onboardingViewModel)
+                                    
+                                case .enterGroup:
+                                    EnterGroupSpaceView(viewModel: onboardingViewModel)
+                                    
+                            }
                         }
+                } else {
+                    LoginView()
+                        .environmentObject(authViewModel)
+                }
+            }
+            .navigationDestination(for: String.self) { destination in
+                if destination == "SimpleOnboarding" {
+                    SimpleOnboardingView(isAuth: $authViewModel.isLoggedIn)
+                        .environmentObject(authViewModel)
+                        .environmentObject(onboardingViewModel)
+                        .environmentObject(memoryCardViewModel)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        onboardingViewModel.navigationPath.append("SimpleOnboarding")
+                    } label: {
+                        Image(systemName: "heart.fill")
+                            .foregroundColor(.mainGreen)
                     }
+                }
             }
         }
-        else {
-            LoginView()
-                .environmentObject(authViewModel)
-        }
+        .environmentObject(onboardingViewModel)
     }
 }
 

--- a/Harmony/Harmony/ContentView.swift
+++ b/Harmony/Harmony/ContentView.swift
@@ -12,12 +12,13 @@ struct ContentView: View {
     @StateObject var onboardingViewModel = OnboardingViewModel()
     
     var body: some View {
-        NavigationStack(path: $onboardingViewModel.navigationPath) {
-            Group {
-                if onboardingViewModel.isOnboardingEnd && authViewModel.isLoggedIn {
-                    MainTabView()
-                        .environmentObject(authViewModel)
-                } else if authViewModel.isLoggedIn && !onboardingViewModel.isOnboardingEnd {
+        Group {
+            if onboardingViewModel.isOnboardingEnd && authViewModel.isLoggedIn {
+                MainTabView()
+                    .environmentObject(authViewModel)
+                    .environmentObject(onboardingViewModel)
+            } else if authViewModel.isLoggedIn && !onboardingViewModel.isOnboardingEnd {
+                NavigationStack(path: $onboardingViewModel.navigationPath) {
                     AllowNotificationView(viewModel: onboardingViewModel)
                         .navigationDestination(for: NavigationDestination.self) { destination in
                             switch destination {
@@ -41,16 +42,15 @@ struct ContentView: View {
                                     
                                 case .enterGroup:
                                     EnterGroupSpaceView(viewModel: onboardingViewModel)
-                                    
                             }
                         }
-                } else {
-                    LoginView()
-                        .environmentObject(authViewModel)
                 }
+            } else {
+                LoginView()
+                    .environmentObject(authViewModel)
+                    .environmentObject(onboardingViewModel)
             }
         }
-        .environmentObject(onboardingViewModel)
     }
 }
 

--- a/Harmony/Harmony/ContentView.swift
+++ b/Harmony/Harmony/ContentView.swift
@@ -11,15 +11,12 @@ struct ContentView: View {
     @StateObject var authViewModel = AuthViewModel()
     @StateObject var onboardingViewModel = OnboardingViewModel()
     
-    @EnvironmentObject var memoryCardViewModel: MemoryCardViewModel
-    
     var body: some View {
         NavigationStack(path: $onboardingViewModel.navigationPath) {
             Group {
                 if onboardingViewModel.isOnboardingEnd && authViewModel.isLoggedIn {
                     MainTabView()
                         .environmentObject(authViewModel)
-                        .environmentObject(memoryCardViewModel)
                 } else if authViewModel.isLoggedIn && !onboardingViewModel.isOnboardingEnd {
                     AllowNotificationView(viewModel: onboardingViewModel)
                         .navigationDestination(for: NavigationDestination.self) { destination in
@@ -50,24 +47,6 @@ struct ContentView: View {
                 } else {
                     LoginView()
                         .environmentObject(authViewModel)
-                }
-            }
-            .navigationDestination(for: String.self) { destination in
-                if destination == "SimpleOnboarding" {
-                    SimpleOnboardingView(isAuth: $authViewModel.isLoggedIn)
-                        .environmentObject(authViewModel)
-                        .environmentObject(onboardingViewModel)
-                        .environmentObject(memoryCardViewModel)
-                }
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        onboardingViewModel.navigationPath.append("SimpleOnboarding")
-                    } label: {
-                        Image(systemName: "heart.fill")
-                            .foregroundColor(.mainGreen)
-                    }
                 }
             }
         }

--- a/Harmony/Harmony/ViewModels/AuthViewModel.swift
+++ b/Harmony/Harmony/ViewModels/AuthViewModel.swift
@@ -13,11 +13,24 @@ final class AuthViewModel: ObservableObject {
     @Published var isLoggedIn = false
     @Published var user: AuthModel
     
-    
+    /*
     init() {
         isLoggedIn = UserDefaults.standard.bool(forKey: "isLoggedIn")
         user = AuthModel(userId: "", nick: "", authProvider: "")
     }
+    */
+    
+    // MARK: - simpleOnboardingView로 앱 기능에 접근하기 위한 init 메서드 임시 수정 코드입니다.(개발용)
+    
+    init() {
+        isLoggedIn = UserDefaults.standard.bool(forKey: "isLoggedIn")
+        user = AuthModel(
+            userId: UserDefaults.standard.string(forKey: "userId") ?? "",
+            nick: UserDefaults.standard.string(forKey: "nick") ?? "",
+            authProvider: UserDefaults.standard.string(forKey: "authProvider") ?? ""
+        )
+    }
+
     
     func loginWithKakao() {
         if UserApi.isKakaoTalkLoginAvailable() {

--- a/Harmony/Harmony/ViewModels/AuthViewModel.swift
+++ b/Harmony/Harmony/ViewModels/AuthViewModel.swift
@@ -13,24 +13,10 @@ final class AuthViewModel: ObservableObject {
     @Published var isLoggedIn = false
     @Published var user: AuthModel
     
-    /*
     init() {
         isLoggedIn = UserDefaults.standard.bool(forKey: "isLoggedIn")
         user = AuthModel(userId: "", nick: "", authProvider: "")
     }
-    */
-    
-    // MARK: - simpleOnboardingView로 앱 기능에 접근하기 위한 init 메서드 임시 수정 코드입니다.(개발용)
-    
-    init() {
-        isLoggedIn = UserDefaults.standard.bool(forKey: "isLoggedIn")
-        user = AuthModel(
-            userId: UserDefaults.standard.string(forKey: "userId") ?? "",
-            nick: UserDefaults.standard.string(forKey: "nick") ?? "",
-            authProvider: UserDefaults.standard.string(forKey: "authProvider") ?? ""
-        )
-    }
-
     
     func loginWithKakao() {
         if UserApi.isKakaoTalkLoginAvailable() {
@@ -106,5 +92,15 @@ final class AuthViewModel: ObservableObject {
             }
         }
     }
+    
+#if DEBUG
+    func logout() {
+        isLoggedIn = false
+        UserDefaults.standard.removeObject(forKey: "isLoggedIn")
+        UserDefaults.standard.removeObject(forKey: "userId")
+        UserDefaults.standard.removeObject(forKey: "nick")
+    }
+#endif
+    
 }
 

--- a/Harmony/Harmony/Views/Auth/LoginView+Debug.swift
+++ b/Harmony/Harmony/Views/Auth/LoginView+Debug.swift
@@ -1,0 +1,78 @@
+//
+//  LoginView+Debug.swift
+//  Harmony
+//
+//  Created by 한범석 on 11/26/24.
+//
+
+import SwiftUI
+
+#if DEBUG
+
+extension LoginView {
+    func handleVIPEntry() {
+        saveUserData(permission: "v")
+        onboardingViewModel.isOnboardingEnd = true
+        authViewModel.isLoggedIn = true
+    }
+    
+    func handleMemberEntry() {
+        saveUserData(permission: "m")
+        onboardingViewModel.isOnboardingEnd = true
+        authViewModel.isLoggedIn = true
+    }
+    
+    func saveUserData(permission: String) {
+        let userData: UserData
+        if permission == "v" {
+            userData = UserData(
+                userId: "yeojeong@naver.com",
+                nick: "윤여정",
+                permissionId: "v",
+                groupId: 1,
+                alias: "할머니 윤여정",
+                deviceToken: "token123"
+            )
+        } else {
+            userData = UserData(
+                userId: "user2@example.com",
+                nick: "최우식",
+                permissionId: "m",
+                groupId: 1,
+                alias: "손자 최우식",
+                deviceToken: "token456"
+            )
+        }
+        UserDefaultsManager.shared.saveUserData(userData)
+    }
+}
+
+struct DebugLoginButtons: View {
+    let handleVIPEntry: () -> Void
+    let handleMemberEntry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Button("VIP로 진입") {
+                handleVIPEntry()
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.mainGreen)
+            .foregroundColor(.white)
+            .cornerRadius(10)
+
+            Button("Member로 진입") {
+                handleMemberEntry()
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.gray2)
+            .foregroundColor(.bl)
+            .cornerRadius(10)
+        }
+    }
+}
+
+#endif
+

--- a/Harmony/Harmony/Views/Auth/LoginView.swift
+++ b/Harmony/Harmony/Views/Auth/LoginView.swift
@@ -1,8 +1,15 @@
+//
+//  LoginView.swift
+//  Harmony
+//
+
 import SwiftUI
 
 struct LoginView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
-    
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var memoryCardViewModel: MemoryCardViewModel
+
     var body: some View {
         GeometryReader { geometry in
             VStack {
@@ -16,6 +23,13 @@ struct LoginView: View {
                 }
                 
                 Spacer()
+#if DEBUG
+                DebugLoginButtons(
+                    handleVIPEntry: handleVIPEntry,
+                    handleMemberEntry: handleMemberEntry
+                )
+                .frame(width: geometry.size.width * 0.9)
+#endif
                 
                 VStack(spacing: 12) {
                     AppleSignInButton(isLoggedIn: $authViewModel.isLoggedIn)
@@ -38,11 +52,6 @@ struct LoginView: View {
             .font(.pretendardBold(size: 24))
         }
         .background(Color.gray1)
-        
     }
 }
 
-#Preview {
-    LoginView()
-        .environmentObject(AuthViewModel())
-}

--- a/Harmony/Harmony/Views/Auth/LoginView.swift
+++ b/Harmony/Harmony/Views/Auth/LoginView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct LoginView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    // 아래의 두 프로퍼티는 LoginView+Debug에서 사용중입니다.
     @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     @EnvironmentObject var memoryCardViewModel: MemoryCardViewModel
 

--- a/Harmony/Harmony/Views/Auth/LoginView.swift
+++ b/Harmony/Harmony/Views/Auth/LoginView.swift
@@ -1,6 +1,4 @@
 import SwiftUI
-import KakaoSDKUser
-
 
 struct LoginView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
@@ -46,4 +44,5 @@ struct LoginView: View {
 
 #Preview {
     LoginView()
+        .environmentObject(AuthViewModel())
 }

--- a/Harmony/Harmony/Views/Home/HomeView.swift
+++ b/Harmony/Harmony/Views/Home/HomeView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct HomeView: View {
     @StateObject private var routineViewModel = RoutineViewModel()
     @EnvironmentObject var memoryCardViewModel: MemoryCardViewModel
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     @State private var isShowingMemoryCardCreate = false
     @State private var isShowingMemoryCardView = false
     @State private var selectedDailyRoutine: DailyRoutine?
@@ -46,13 +48,20 @@ struct HomeView: View {
                             .scaledToFit()
                             .frame(height: 30)
                     }
+#if DEBUG
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        Image(systemName: "person.circle")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(height: 30)
-                            .foregroundColor(.black)
+                        Button(action: {
+                            authViewModel.logout()
+                            onboardingViewModel.navigationPath.removeLast(onboardingViewModel.navigationPath.count)
+                        }) {
+                            Image(systemName: "heart.fill")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(height: 30)
+                                .foregroundColor(.mainGreen)
+                        }
                     }
+#endif
                 }
             }
             .navigationViewStyle(StackNavigationViewStyle())

--- a/Harmony/Harmony/Views/Home/HomeView.swift
+++ b/Harmony/Harmony/Views/Home/HomeView.swift
@@ -54,11 +54,11 @@ struct HomeView: View {
                             authViewModel.logout()
                             onboardingViewModel.navigationPath.removeLast(onboardingViewModel.navigationPath.count)
                         }) {
-                            Image(systemName: "heart.fill")
+                            Image(systemName: "person.circle")
                                 .resizable()
                                 .scaledToFit()
                                 .frame(height: 30)
-                                .foregroundColor(.mainGreen)
+                                .foregroundColor(.black)
                         }
                     }
 #endif

--- a/Harmony/Harmony/Views/Onboarding/SimpleOnboardingView.swift
+++ b/Harmony/Harmony/Views/Onboarding/SimpleOnboardingView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SimpleOnboardingView: View {
     @Binding var isAuth: Bool
-    @State var isOnboarding = false // 상태 초기화 추가
+    @State var isOnboarding = false
     @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject var onboardingViewModel: OnboardingViewModel
 
@@ -48,9 +48,9 @@ struct SimpleOnboardingView: View {
                 .multilineTextAlignment(.center)
                 
                 VStack(spacing: 15) {
-                    // VIP 버튼
+                    
                     Button {
-                        handleVIPSelection()
+//                        handleVIPSelection()
                     } label: {
                         Text("VIP")
                             .font(.system(size: 18, weight: .semibold))
@@ -61,9 +61,8 @@ struct SimpleOnboardingView: View {
                             .cornerRadius(10)
                     }
                     
-                    // Member 버튼
                     Button {
-                        handleMemberSelection()
+//                        handleMemberSelection()
                     } label: {
                         Text("Member")
                             .font(.system(size: 18, weight: .semibold))
@@ -74,9 +73,8 @@ struct SimpleOnboardingView: View {
                             .cornerRadius(10)
                     }
                     
-                    // Onboarding 버튼
                     Button {
-                        self.isOnboarding = true // Onboarding 화면 활성화
+                        self.isOnboarding = true
                     } label: {
                         Text("Onboarding")
                             .font(.system(size: 18, weight: .semibold))
@@ -113,19 +111,20 @@ struct SimpleOnboardingView: View {
     }
 }
 
+/*
 extension SimpleOnboardingView {
     private func handleVIPSelection() {
-        saveUserData(permission: "v") // VIP 데이터 저장
-        onboardingViewModel.isOnboardingEnd = true // 온보딩 완료 설정
-        authViewModel.isLoggedIn = true // 로그인 상태로 변경
-        isAuth = true // MainTabView로 이동
+        saveUserData(permission: "v")
+        onboardingViewModel.isOnboardingEnd = true
+        authViewModel.isLoggedIn = true
+        isAuth = true
     }
     
     private func handleMemberSelection() {
-        saveUserData(permission: "m") // Member 데이터 저장
-        onboardingViewModel.isOnboardingEnd = true // 온보딩 완료 설정
-        authViewModel.isLoggedIn = true // 로그인 상태로 변경
-        isAuth = true // MainTabView로 이동
+        saveUserData(permission: "m")
+        onboardingViewModel.isOnboardingEnd = true
+        authViewModel.isLoggedIn = true
+        isAuth = true 
     }
 }
 
@@ -153,3 +152,4 @@ func saveUserData(permission: String) {
     
     UserDefaultsManager.shared.saveUserData(userData)
 }
+*/

--- a/Harmony/Harmony/Views/Onboarding/SimpleOnboardingView.swift
+++ b/Harmony/Harmony/Views/Onboarding/SimpleOnboardingView.swift
@@ -1,10 +1,18 @@
+//
+//  SimpleOnboardingView.swift
+//  Harmony
+//
+//  Created by 한범석 on 7/15/24.
+//
+
 import SwiftUI
 
 struct SimpleOnboardingView: View {
     @Binding var isAuth: Bool
-    @State var isOnboarding = false
-    @EnvironmentObject var memoryCardViewModel: MemoryCardViewModel
-    
+    @State var isOnboarding = false // 상태 초기화 추가
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
+
     var body: some View {
         ZStack {
             Color.subGreen.ignoresSafeArea()
@@ -17,8 +25,6 @@ struct SimpleOnboardingView: View {
                     .frame(height: 75)
                     .padding(.top, 50)
                     .padding(.bottom, 20)
-                
-                
                 
                 VStack(spacing: 3) {
                     HStack {
@@ -40,13 +46,11 @@ struct SimpleOnboardingView: View {
                         .foregroundColor(.bl)
                 }
                 .multilineTextAlignment(.center)
-
-                
                 
                 VStack(spacing: 15) {
+                    // VIP 버튼
                     Button {
-                        saveUserData(permission: "v")
-                        isAuth = true
+                        handleVIPSelection()
                     } label: {
                         Text("VIP")
                             .font(.system(size: 18, weight: .semibold))
@@ -57,9 +61,9 @@ struct SimpleOnboardingView: View {
                             .cornerRadius(10)
                     }
                     
+                    // Member 버튼
                     Button {
-                        saveUserData(permission: "m")
-                        isAuth = true
+                        handleMemberSelection()
                     } label: {
                         Text("Member")
                             .font(.system(size: 18, weight: .semibold))
@@ -70,8 +74,9 @@ struct SimpleOnboardingView: View {
                             .cornerRadius(10)
                     }
                     
+                    // Onboarding 버튼
                     Button {
-                        self.isOnboarding = true
+                        self.isOnboarding = true // Onboarding 화면 활성화
                     } label: {
                         Text("Onboarding")
                             .font(.system(size: 18, weight: .semibold))
@@ -103,19 +108,29 @@ struct SimpleOnboardingView: View {
         }
         .fullScreenCover(isPresented: $isOnboarding) {
             LoginView()
+                .environmentObject(authViewModel)
         }
     }
 }
 
-struct SimpleOnboardingView_Previews: PreviewProvider {
-    static var previews: some View {
-        SimpleOnboardingView(isAuth: .constant(false))
+extension SimpleOnboardingView {
+    private func handleVIPSelection() {
+        saveUserData(permission: "v") // VIP 데이터 저장
+        onboardingViewModel.isOnboardingEnd = true // 온보딩 완료 설정
+        authViewModel.isLoggedIn = true // 로그인 상태로 변경
+        isAuth = true // MainTabView로 이동
+    }
+    
+    private func handleMemberSelection() {
+        saveUserData(permission: "m") // Member 데이터 저장
+        onboardingViewModel.isOnboardingEnd = true // 온보딩 완료 설정
+        authViewModel.isLoggedIn = true // 로그인 상태로 변경
+        isAuth = true // MainTabView로 이동
     }
 }
 
 func saveUserData(permission: String) {
     let userData: UserData
-    
     if permission == "v" {
         userData = UserData(
             userId: "yeojeong@naver.com",
@@ -137,9 +152,4 @@ func saveUserData(permission: String) {
     }
     
     UserDefaultsManager.shared.saveUserData(userData)
-}
-
-
-#Preview {
-    SimpleOnboardingView(isAuth: .constant(false))
 }


### PR DESCRIPTION
## 💡 Issue Number
- #133 

## 🤷‍♂️ Description
- 뷰 우측 상단에 SimpleOnboardingView로 이동할 수 있는 버튼 추가.
- 계정 혹은 권한으로 앱에 진입할 수 없는 문제 등 디버깅.

## ✳️ Remarks
- LoginView에서 필요하지 않은 의존성인 import KakaoSDKUser를 제거했습니다.(authViewModel.loginWithKakao() 메서드는 AuthViewModel에서 처리됨)
- ContentView에서는 SimpleOnboardingView로의 이동 기능 추가와 네비게이션 상태 관리의 일관성을 위해 NavigationStack과 Group으로 분기 처리 구문 전체를 감싸는 방식으로 수정하였고 기존 코드의 기능은 모두 정상적으로 유지됩니다.
