### PR TITLE
[Refactor] 소셜 로그인 로직 리팩토링, 디자인 가이드에 맞춰 로그인 버튼 개선

### DIFF
--- a/Harmony/Harmony.xcodeproj/project.pbxproj
+++ b/Harmony/Harmony.xcodeproj/project.pbxproj
@@ -592,11 +592,12 @@
 			};
 			buildConfigurationList = BE99A1802C44AA230011F371 /* Build configuration list for PBXProject "Harmony" */;
 			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = BE99A17C2C44AA230011F371;
 			packageReferences = (

--- a/Harmony/Harmony.xcodeproj/project.pbxproj
+++ b/Harmony/Harmony.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		55A10B2C2C510475001728EF /* CustomTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A10B2B2C510475001728EF /* CustomTextFieldView.swift */; };
 		55A10B2E2C5115BF001728EF /* CustomDropdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A10B2D2C5115BF001728EF /* CustomDropdownView.swift */; };
 		55A10B302C5119AB001728EF /* RegisterProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A10B2F2C5119AB001728EF /* RegisterProfileView.swift */; };
+		55A479B32CF5FBE900605CA4 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A479B22CF5FBE900605CA4 /* AuthService.swift */; };
 		55A558712C561ECF00DF2CFF /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 55A558702C561ECF00DF2CFF /* KakaoSDK */; };
 		55A558732C56575400DF2CFF /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A558722C56575400DF2CFF /* AuthViewModel.swift */; };
 		55A558752C57946B00DF2CFF /* AuthModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A558742C57946B00DF2CFF /* AuthModel.swift */; };
@@ -153,6 +154,7 @@
 		55A10B2B2C510475001728EF /* CustomTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextFieldView.swift; sourceTree = "<group>"; };
 		55A10B2D2C5115BF001728EF /* CustomDropdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDropdownView.swift; sourceTree = "<group>"; };
 		55A10B2F2C5119AB001728EF /* RegisterProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterProfileView.swift; sourceTree = "<group>"; };
+		55A479B22CF5FBE900605CA4 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		55A558722C56575400DF2CFF /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		55A558742C57946B00DF2CFF /* AuthModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthModel.swift; sourceTree = "<group>"; };
 		55A6D3BF2C6A56B400627DD2 /* AppleSignInButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInButton.swift; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 				BEA2AA872C50CF940033AAEF /* AzureAIService.swift */,
 				3EE527C12C57A92E00B16DB8 /* RoutineService.swift */,
 				5573E97D2C5B193B00284775 /* OnboardingService.swift */,
+				55A479B22CF5FBE900605CA4 /* AuthService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -639,6 +642,7 @@
 				5500034E2C5377E700B00635 /* NotificationManager.swift in Sources */,
 				C47B35BF2C5A4412006A3561 /* GroupViewModel.swift in Sources */,
 				C49DBE202C4FAEA100B1A87D /* AnswerEditView.swift in Sources */,
+				55A479B32CF5FBE900605CA4 /* AuthService.swift in Sources */,
 				BE884B5F2C59E31000D9BCCA /* ImagePicker.swift in Sources */,
 				55A10B282C50C506001728EF /* InputVIPInfoView.swift in Sources */,
 				BE884B772C5EFCCE00D9BCCA /* MemoryCardChatHistoryView.swift in Sources */,

--- a/Harmony/Harmony/ContentView.swift
+++ b/Harmony/Harmony/ContentView.swift
@@ -12,38 +12,41 @@ struct ContentView: View {
     @StateObject var onboardingViewModel = OnboardingViewModel()
     
     var body: some View {
-        if onboardingViewModel.isOnboardingEnd && authViewModel.isLoggedIn  {
-            MainTabView()
-        } else if authViewModel.isLoggedIn && !onboardingViewModel.isOnboardingEnd {
-            NavigationStack(path: $onboardingViewModel.navigationPath) {
-                AllowNotificationView(viewModel: onboardingViewModel)
-                    .navigationDestination(for: NavigationDestination.self) { destination in
-                        switch destination {
-                        case .createGroup:
-                            CreateGroupSpaceView(viewModel: onboardingViewModel)
-                        case .inputVIPInfo:
-                            InputVIPInfoView(viewModel: onboardingViewModel)
-                            
-                        case .inputUserInfo:
-                            InputUserInfoView(viewModel: onboardingViewModel)
-                            
-                        case .inviteVIP:
-                            InviteVIPView(viewModel: onboardingViewModel)
-                            
-                        case .registerProfile:
-                            RegisterProfileView(viewModel: onboardingViewModel)
-                            
-                        case .joinGroup:
-                            JoinGroupSpaceView(viewModel: onboardingViewModel)
-                            
-                        case .enterGroup:
-                            EnterGroupSpaceView(viewModel: onboardingViewModel)
-                            
-                        }
+        if authViewModel.isLoggedIn  {
+            if authViewModel.groupId > 0 || onboardingViewModel.isOnboardingEnd {
+                MainTabView()
+            } else if !onboardingViewModel.isOnboardingEnd {
+                Group {
+                    NavigationStack(path: $onboardingViewModel.navigationPath) {
+                        AllowNotificationView()
+                            .navigationDestination(for: NavigationDestination.self) { destination in
+                                switch destination {
+                                case .createGroup:
+                                    CreateGroupSpaceView()
+                                case .inputVIPInfo:
+                                    InputVIPInfoView()
+                                    
+                                case .inputUserInfo:
+                                    InputUserInfoView()
+                                    
+                                case .inviteVIP:
+                                    InviteVIPView()
+                                    
+                                case .registerProfile:
+                                    RegisterProfileView()
+                                    
+                                case .joinGroup:
+                                    JoinGroupSpaceView()
+                                    
+                                case .enterGroup:
+                                    EnterGroupSpaceView()
+                                }
+                            }
                     }
+                }
+                .environmentObject(onboardingViewModel)
             }
-        }
-        else {
+        } else {
             LoginView()
                 .environmentObject(authViewModel)
         }

--- a/Harmony/Harmony/ContentView.swift
+++ b/Harmony/Harmony/ContentView.swift
@@ -15,6 +15,7 @@ struct ContentView: View {
         if authViewModel.isLoggedIn  {
             if authViewModel.groupId > 0 || onboardingViewModel.isOnboardingEnd {
                 MainTabView()
+                    .environmentObject(authViewModel)
             } else if !onboardingViewModel.isOnboardingEnd {
                 Group {
                     NavigationStack(path: $onboardingViewModel.navigationPath) {

--- a/Harmony/Harmony/ContentView.swift
+++ b/Harmony/Harmony/ContentView.swift
@@ -17,40 +17,38 @@ struct ContentView: View {
                 MainTabView()
                     .environmentObject(authViewModel)
             } else if !onboardingViewModel.isOnboardingEnd {
-                Group {
-                    NavigationStack(path: $onboardingViewModel.navigationPath) {
-                        AllowNotificationView()
-                            .navigationDestination(for: NavigationDestination.self) { destination in
-                                switch destination {
-                                case .createGroup:
-                                    CreateGroupSpaceView()
-                                case .inputVIPInfo:
-                                    InputVIPInfoView()
-                                    
-                                case .inputUserInfo:
-                                    InputUserInfoView()
-                                    
-                                case .inviteVIP:
-                                    InviteVIPView()
-                                    
-                                case .registerProfile:
-                                    RegisterProfileView()
-                                    
-                                case .joinGroup:
-                                    JoinGroupSpaceView()
-                                    
-                                case .enterGroup:
-                                    EnterGroupSpaceView()
-                                }
+                NavigationStack(path: $onboardingViewModel.navigationPath) {
+                    AllowNotificationView()
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            switch destination {
+                            case .createGroup:
+                                CreateGroupSpaceView()
+                            case .inputVIPInfo:
+                                InputVIPInfoView()
+                                
+                            case .inputUserInfo:
+                                InputUserInfoView()
+                                
+                            case .inviteVIP:
+                                InviteVIPView()
+                                
+                            case .registerProfile:
+                                RegisterProfileView()
+                                
+                            case .joinGroup:
+                                JoinGroupSpaceView()
+                                
+                            case .enterGroup:
+                                EnterGroupSpaceView()
                             }
-                    }
+                        }
                 }
                 .environmentObject(onboardingViewModel)
             }
         } else {
             LoginView()
                 .environmentObject(authViewModel)
-
+            
         }
     }
 }

--- a/Harmony/Harmony/HarmonyApp.swift
+++ b/Harmony/Harmony/HarmonyApp.swift
@@ -19,11 +19,12 @@ struct HarmonyApp: App {
     
     init() {
         // Kakao SDK 초기화
-        guard let nativeAppKey = Bundle.main.nativeAppKey else {
+        if let nativeAppKey = Bundle.main.nativeAppKey  {
+            KakaoSDK.initSDK(appKey: nativeAppKey)
+        } else {
             print("카카오 네이티브 앱 키를 로드하지 못했음")
-            return
+            // TODO: - 네이티브 앱 키를 로드하지 못했을 때 처리해줘야하는 로직
         }
-        KakaoSDK.initSDK(appKey: nativeAppKey)
     }
     
     var body: some Scene {

--- a/Harmony/Harmony/Models/AuthModel.swift
+++ b/Harmony/Harmony/Models/AuthModel.swift
@@ -5,7 +5,6 @@
 //  Created by 한수빈 on 7/29/24.
 //
 
-import Foundation
 
 struct AuthResponse: Codable {
     let message: String
@@ -14,15 +13,8 @@ struct AuthResponse: Codable {
 }
 
 struct AuthModel: Codable {
-    var userId: String
-    var nick: String
-    var profile: String?
-    var authProvider: String
-    var socialToken: String?
-    var refreshToken: String?
-    var socialTokenExpiredAt: String?
-    var lastLoginAt: String?
-    var createdAt: String?
-    var updatedAt: String?
-    var deletedAt: String?
+    let nick: String
+    let authProvider: String
+    let groupId: Int
+    let permissionId: String?
 }

--- a/Harmony/Harmony/Models/OnboardingModel.swift
+++ b/Harmony/Harmony/Models/OnboardingModel.swift
@@ -5,7 +5,7 @@
 //  Created by 한수빈 on 8/1/24.
 //
 
-import Foundation
+//import Foundation
 
 struct HarmonyGroup: Codable {
     let groupId: Int

--- a/Harmony/Harmony/Services/AuthService.swift
+++ b/Harmony/Harmony/Services/AuthService.swift
@@ -1,0 +1,62 @@
+//
+//  AuthService.swift
+//  Harmony
+//
+//  Created by 한수빈 on 11/26/24.
+//
+
+import Alamofire
+import AuthenticationServices
+
+final class AuthService {
+    
+    static let shared = AuthService()
+    private let session: Session
+    
+    private init() {
+        let interceptor = AuthInterceptor()
+        self.session = Session(interceptor: interceptor)
+    }
+    
+    private let baseURL: String = {
+        guard let baseURL = Bundle.main.infoDictionary?["BASE_URL"] as? String else {
+            fatalError("BASE_URL is not set in Info.plist")
+        }
+        return baseURL
+    }()
+    
+    func loginServiceKakao(userId: String, nick: String, socialToken: String, refreshToken: String, socialTokenExpiredAt: String) async throws -> AuthResponse {
+        let endpoint = baseURL + "/user/signup"
+        let parameters: Parameters = [ "userId": userId,
+                                   "nick": nick,
+                                   "authProvider": "kakao",
+                                   "socialToken": socialToken,
+                                   "refreshToken": refreshToken,
+                                   "socialTokenExpiredAt": socialTokenExpiredAt ]
+        
+        let response: AuthResponse = try await session.request(endpoint, method: .post, parameters: parameters, encoding: JSONEncoding.default)
+            .validate()
+            .serializingDecodable(AuthResponse.self)
+            .value
+        
+        return response
+    }
+    
+    func loginServiceApple(appleIDCredential: ASAuthorizationAppleIDCredential) async throws -> AuthResponse {
+        let endpoint = baseURL + "/user/signup"
+        let parameters: Parameters = [ "userId": appleIDCredential.user,
+                                   "nick": (appleIDCredential.fullName?.familyName) ?? "" + (appleIDCredential.fullName?.givenName ?? ""),
+                                   "authProvider": "apple",
+                                   "socialToken": String(data: appleIDCredential.identityToken!, encoding: .utf8)!,
+                                   "refreshToken": "",
+                                   "socialTokenExpiredAt": ""]
+        
+        
+        let response: AuthResponse = try await session.request(endpoint, method: .post, parameters: parameters, encoding: JSONEncoding.default)
+            .validate()
+            .serializingDecodable(AuthResponse.self)
+            .value
+        
+        return response
+    }
+}

--- a/Harmony/Harmony/Services/OnboardingService.swift
+++ b/Harmony/Harmony/Services/OnboardingService.swift
@@ -5,19 +5,24 @@
 //  Created by 한수빈 on 8/1/24.
 //
 
-import Foundation
+import UIKit
 import Combine
 import Alamofire
-import UIKit
-
+// TODO: - 요청, 응답에 필요한 모델 또한 리팩토링 필요
 final class OnboardingService {
-    private let baseURL = "https://harmony-api.azurewebsites.net"
     private let session: Session
     
     init() {
         let interceptor = AuthInterceptor()
         self.session = Session(interceptor: interceptor)
     }
+    
+    private let baseURL: String = {
+        guard let baseURL = Bundle.main.infoDictionary?["BASE_URL"] as? String else {
+            fatalError("BASE_URL is not set in Info.plist")
+        }
+        return baseURL
+    }()
     
     func createGroup(name: String, userId: String, deviceToken: String) async throws -> (Int, String, String, String) {
         let parameters: [String: Any] = [

--- a/Harmony/Harmony/Utilities/Extensions/AppDelegate+Extentions.swift
+++ b/Harmony/Harmony/Utilities/Extensions/AppDelegate+Extentions.swift
@@ -11,7 +11,7 @@ import KakaoSDKAuth
 import KakaoSDKUser
 
 
-class AppDelegate: NSObject, UIApplicationDelegate {
+final class AppDelegate: NSObject, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
 //        let center = UNUserNotificationCenter.current()
@@ -55,11 +55,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         if (AuthApi.isKakaoTalkLoginUrl(url)) {
-            
             return AuthController.handleOpenUrl(url: url)
         }
-        
-        
         return false
     }
     
@@ -78,10 +75,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     
 }
 
-/// 푸쉬 알림 관련 설정
+// MARK: - 원격 푸쉬 관련 설정. SwiftUI에서 AppDelegate를 사용하지 않고 처리할 수 있는 방법이 있는지 확인
 extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        let info = response.notification.request.content.userInfo
+        _ = response.notification.request.content.userInfo
         completionHandler()
     }
     

--- a/Harmony/Harmony/ViewModels/AuthViewModel.swift
+++ b/Harmony/Harmony/ViewModels/AuthViewModel.swift
@@ -7,89 +7,93 @@
 
 import Foundation
 import KakaoSDKUser
-import Alamofire
+import AuthenticationServices
 
+@MainActor
 final class AuthViewModel: ObservableObject {
-    @Published var isLoggedIn = false
-    @Published var user: AuthModel
-    
-    
-    init() {
-        isLoggedIn = UserDefaults.standard.bool(forKey: "isLoggedIn")
-        user = AuthModel(userId: "", nick: "", authProvider: "")
+    @Published var isLoggedIn: Bool {
+        didSet {
+            UserDefaults.standard.setValue(isLoggedIn, forKey: "isLoggedIn")
+        }
+    }
+    @Published var groupId: Int {
+        didSet {
+            UserDefaults.standard.setValue(groupId, forKey: "groupId")
+        }
     }
     
+    init() {
+        self.isLoggedIn = UserDefaults.standard.bool(forKey: "isLoggedIn")
+        self.groupId = UserDefaults.standard.integer(forKey: "groupId")
+    }
+    
+    // MARK: - 카카오 로그인
     func loginWithKakao() {
         if UserApi.isKakaoTalkLoginAvailable() {
             UserApi.shared.loginWithKakaoTalk { (oauthToken, error) in
                 if let error {
                     print(error)
                 } else {
-                    print("loginWithKakaoTalk() success.")
-                    print("오어스토큰. \(oauthToken)")
                     guard let oauthToken else { return }
-                    
-                    UserDefaults.standard.setValue(oauthToken.accessToken, forKey: "socialToken")
-                    UserDefaults.standard.setValue(oauthToken.expiredAt.toString(), forKey: "expiredAt")
-                    UserDefaults.standard.setValue(oauthToken.refreshToken, forKey: "refreshToken")
-                    
-                    self.getUserInfo()
+//                    String(data: oauthToken, encoding: .utf8)
+                    self.getUserInfo(socialToken: oauthToken.accessToken, expiredAt: oauthToken.expiredAt.toString(), refreshToken: oauthToken.refreshToken)
+                }
+            }
+        } else { // 카카오톡 미설치 시 앱스토어로 이동
+            if let url = URL(string: "https://apps.apple.com/kr/app/kakaotalk/id362057947") {
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url)
                 }
             }
         }
     }
     
-    private func loginService() {
-        let endpoint = "https://harmony-api.azurewebsites.net/user/signup"
-        let params: Parameters = [ "userId": self.user.userId,
-                                   "nick": self.user.nick,
-                                   //"profile": self.user.profile ?? "",
-                                   "authProvider": self.user.authProvider,
-                                   "socialToken": self.user.socialToken ?? "",
-                                   "refreshToken": self.user.refreshToken ?? "",
-                                   "socialTokenExpiredAt": self.user.socialTokenExpiredAt ?? ""]
-        print(params)
-        AF.request(endpoint, method: .post, parameters: params)
-            .validate()
-            .responseDecodable(of: AuthResponse.self) { res in
-                switch res.result {
-                case .success(let result):
-                    UserDefaults.standard.setValue(result.token, forKey: "serverToken")
-                    print("제발 \(result)")
-                case .failure(let error):
-                    print(error.localizedDescription)
-                }
-            }
-    }
-    
-    private func getUserInfo() {
+    // MARK: - 카카오 유저 정보조회
+    private func getUserInfo(socialToken: String, expiredAt: String, refreshToken: String) {
         UserApi.shared.me { (user, error) in
             if let error {
                 print(error)
             } else {
                 if let user {
-                    guard let id = user.id,
+                    guard let userNumId = user.id,
                           let nick = user.kakaoAccount?.profile?.nickname
-                         // let profile = user.kakaoAccount?.profile?.profileImageUrl 
-                    else { return }
-                    UserDefaults.standard.setValue(id, forKey: "userId")
-                    UserDefaults.standard.setValue(nick, forKey: "nick")
-                    //UserDefaults.standard.setValue(profile, forKey: "profile")
-                    self.user.userId = String(id)
-                    self.user.nick = nick
-                    self.user.authProvider = "kakao"
-                    //self.user.profile = UserDefaults.standard.string(forKey: "profile")
-                    self.user.socialToken = UserDefaults.standard.string(forKey: "socialToken")
-                    self.user.refreshToken = UserDefaults.standard.string(forKey: "refreshToken")
-                    self.user.socialTokenExpiredAt = UserDefaults.standard.string(forKey: "expiredAt")
+                    else {
+                        print("error in\(#function)")
+                        return
+                    }
                     
-                    self.loginService()
-                        
-
-                    self.isLoggedIn = true
-                    UserDefaults.standard.set(true, forKey: "isLoggedIn")
-                    
+                    let userId = "\(userNumId)"
+                    Task {
+                        do {
+                            let response = try await AuthService.shared.loginServiceKakao(userId: userId, nick: nick, socialToken: socialToken, refreshToken: refreshToken, socialTokenExpiredAt: expiredAt)
+                            UserDefaults.standard.set(response.token, forKey: "serverToken")
+                            UserDefaults.standard.set(response.user.nick, forKey: "nick")
+                            UserDefaults.standard.set(response.user.authProvider, forKey: "authProvider")
+                            UserDefaults.standard.set(response.user.groupId, forKey: "groupId")
+                            self.isLoggedIn = true
+                        } catch {
+                            print("error in \(#function)")
+                            return
+                        }
+                    }
                 }
+            }
+        }
+    }
+    
+    
+    func loginWithApple(appleIDCredential: ASAuthorizationAppleIDCredential) {
+        Task {
+            do {
+                let response = try await AuthService.shared.loginServiceApple(appleIDCredential: appleIDCredential)
+                UserDefaults.standard.set(response.token, forKey: "serverToken")
+                UserDefaults.standard.set(response.user.nick, forKey: "nick")
+                UserDefaults.standard.set(response.user.authProvider, forKey: "authProvider")
+                self.isLoggedIn = true
+                UserDefaults.standard.set(response.user.groupId, forKey: "groupId")
+            } catch {
+                print("error in \(#function)")
+                return
             }
         }
     }

--- a/Harmony/Harmony/ViewModels/OnboardingViewModel.swift
+++ b/Harmony/Harmony/ViewModels/OnboardingViewModel.swift
@@ -65,7 +65,7 @@ final class OnboardingViewModel: ObservableObject {
     
     init(apiService: OnboardingService = OnboardingService()) {
         self.apiService = apiService
-        self.isOnboardingEnd = UserDefaults.standard.bool(forKey: "isOnboardingEnd")
+        self.isOnboardingEnd = false
         print("OnboardingViewModel initialized")
     }
     
@@ -171,7 +171,6 @@ final class OnboardingViewModel: ObservableObject {
                     self.currentUserGroup = response.userGroup
                     self.isLoading = false
                     print("Onboarding info updated successfully - userId: \(response.userGroup.userId), groupId: \(response.userGroup.groupId)")
-                    UserDefaults.standard.setValue(true, forKey: "isOnboardingEnd")
                     self.isOnboardingEnd = true
                     self.navigateToRoot()
                 }
@@ -198,7 +197,7 @@ final class OnboardingViewModel: ObservableObject {
 }
 
 
-@frozen enum NavigationDestination: Hashable {
+enum NavigationDestination: Hashable {
     case createGroup
     case inputVIPInfo
     case inputUserInfo

--- a/Harmony/Harmony/Views/Auth/AppleSignInButton.swift
+++ b/Harmony/Harmony/Views/Auth/AppleSignInButton.swift
@@ -11,88 +11,29 @@ import AuthenticationServices
 
 
 struct AppleSignInButton: View {
-    @Binding var isLoggedIn: Bool
+    var completion: (ASAuthorizationAppleIDCredential) -> Void
     
     var body: some View {
         SignInWithAppleButton(
+            .continue,
+            
             onRequest: { request in
-                request.requestedScopes = [.fullName, .email]
-            },
+            request.requestedScopes = [.fullName, .email]
+        },
+            
             onCompletion: { result in
-                switch result {
-                case .success(let authResults):
-                    print("Apple Login Successful")
-                    
-                    switch authResults.credential {
-                    case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                        // 계정 정보 가져오기
-                        let userId = appleIDCredential.user
-                        let fullName = appleIDCredential.fullName
-                        let nick = (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
-                        let email = appleIDCredential.email ?? ""
-                        DispatchQueue.main.async {
-                            // UserDefaults에 계정 정보 저장
-                            UserDefaults.standard.set(userId, forKey: "userId")
-                            UserDefaults.standard.set(nick, forKey: "nick")
-                            UserDefaults.standard.set(email, forKey: "email")
-                        }
-                        // 백엔드에 로그인 요청
-                        login(userId, email, nick)
-                        
-                    default:
-                        break
-                    }
-                case .failure(let error):
-                    print(error.localizedDescription)
-                    print("error")
+            switch result {
+            case .success(let authResults):
+                switch authResults.credential {
+                case let appleIDCredential as ASAuthorizationAppleIDCredential:
+                    completion(appleIDCredential)
+                default:
+                    break
                 }
+            case .failure(let error):
+                print(error.localizedDescription)
             }
-        )
-        .frame(width: UIScreen.main.bounds.width * 0.9, height: 50)
-        .cornerRadius(5)
-    }
-    
-    
-    
-    func login(_ userId: String, _ email: String, _ nick: String) {
-        let endpoint = "https://harmony-api.azurewebsites.net/user/signup"
-        let params: Parameters = [
-            "userId": userId,
-            "nick": nick,
-            "authProvider": "apple",
-            "socialToken": email,
-            "refreshToken": "",
-            "socialTokenExpiredAt": ""
-        ]
-        print(params)
-
-        AF.request(endpoint, method: .post, parameters: params)
-            .validate()
-            .responseDecodable(of: AuthResponse.self) { res in
-                switch res.result {
-                case .success(let result):
-                    print("User received: \(result.user)")
-                    DispatchQueue.main.async {
-                        UserDefaults.standard.setValue(result.token, forKey: "serverToken")
-                        UserDefaults.standard.set(true, forKey: "isLoggedIn")
-                        isLoggedIn = true
-                    }
-                case .failure(let error):
-                    print("Login failed: \(error.localizedDescription)")
-                }
-            }
+        })
     }
     
 }
-
-struct LoginInfo: Codable {
-    let userId: String
-    let nick: String
-    let profile: String?
-    let authProvider: String
-    let socialToken: String
-    let refreshToken: String?
-    let socialTokenExpiredAt: String?
-}
-
-

--- a/Harmony/Harmony/Views/Auth/LoginView+Debug.swift
+++ b/Harmony/Harmony/Views/Auth/LoginView+Debug.swift
@@ -12,13 +12,13 @@ import SwiftUI
 extension LoginView {
     func handleVIPEntry() {
         saveUserData(permission: "v")
-        onboardingViewModel.isOnboardingEnd = true
+        authViewModel.groupId = 1
         authViewModel.isLoggedIn = true
     }
     
     func handleMemberEntry() {
         saveUserData(permission: "m")
-        onboardingViewModel.isOnboardingEnd = true
+        authViewModel.groupId = 1
         authViewModel.isLoggedIn = true
     }
     

--- a/Harmony/Harmony/Views/Auth/LoginView.swift
+++ b/Harmony/Harmony/Views/Auth/LoginView.swift
@@ -25,7 +25,6 @@ struct LoginView: View {
                     handleVIPEntry: handleVIPEntry,
                     handleMemberEntry: handleMemberEntry
                 )
-                .frame(width: geometry.size.width * 0.9)
 #endif
 
                 AppleSignInButton(completion: { appleIDCredential in authViewModel.loginWithApple(appleIDCredential: appleIDCredential)})

--- a/Harmony/Harmony/Views/Auth/LoginView.swift
+++ b/Harmony/Harmony/Views/Auth/LoginView.swift
@@ -25,6 +25,7 @@ struct LoginView: View {
                     handleVIPEntry: handleVIPEntry,
                     handleMemberEntry: handleMemberEntry
                 )
+                .padding(.horizontal)
 #endif
 
                 AppleSignInButton(completion: { appleIDCredential in authViewModel.loginWithApple(appleIDCredential: appleIDCredential)})
@@ -37,13 +38,13 @@ struct LoginView: View {
                     HStack {
                         KakaoLogoView(size: 20)
                         Text("카카오로 계속하기")
-                            .font(.pretendardMedium(size: 20))
+                            .font(.system(size: 20))
                             .foregroundStyle(Color(white: 0, opacity: 85))
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: 60)
                 .background(Color.init(hex: "FEE500"))
-                .cornerRadius(8, corners: .allCorners)
+                .cornerRadius(6, corners: .allCorners)
                 .padding(.horizontal)
             }
             .padding(.bottom, 30)

--- a/Harmony/Harmony/Views/Auth/LoginView.swift
+++ b/Harmony/Harmony/Views/Auth/LoginView.swift
@@ -1,49 +1,106 @@
 import SwiftUI
 import KakaoSDKUser
+import AuthenticationServices
 
 
 struct LoginView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var onboardingViewModel: AuthViewModel
     
     var body: some View {
-        GeometryReader { geometry in
-            VStack {
-                Spacer()
-                
-                VStack(alignment: .center, spacing: 22) {
-                    Text("가족과 함께 만드는 소중한 추억")
-                        .foregroundColor(.gray5)
-                        .font(.pretendardMedium(size: 18))
-                    Image("harmony-logo")
-                }
-                
-                Spacer()
-                
-                VStack(spacing: 12) {
-                    AppleSignInButton(isLoggedIn: $authViewModel.isLoggedIn)
-                    
-                    Button {
-                        authViewModel.loginWithKakao()
-                    } label: {
-                        Text("카카오로 계속하기")
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(.yellow)
-                            .foregroundColor(.bl)
-                            .cornerRadius(10)
-                    }
-                    .frame(width: geometry.size.width * 0.9)
-                }
-                .padding(.bottom, 30)
+        VStack(alignment: .center) {
+            Spacer()
+            VStack(alignment: .center, spacing: 22) {
+                Text("가족과 함께 만드는 소중한 추억")
+                    .foregroundColor(.gray5)
+                    .font(.pretendardMedium(size: 18))
+                Image("harmony-logo")
             }
-            .frame(width: geometry.size.width)
-            .font(.pretendardBold(size: 24))
+            
+            Spacer()
+            // TODO: - 최근 로그인했던 방식 저장하는 로직 필요
+            VStack() {
+                AppleSignInButton(completion: { appleIDCredential in authViewModel.loginWithApple(appleIDCredential: appleIDCredential)})
+                    .padding(.horizontal)
+                    .frame(height: 60)
+  
+                Button {
+                    authViewModel.loginWithKakao()
+                } label: {
+                    HStack {
+                        KakaoLogoView(size: 20)
+                        Text("카카오로 계속하기")
+                            .font(.pretendardMedium(size: 20))
+                            .foregroundStyle(Color(white: 0, opacity: 85))
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: 60)
+                .background(Color.init(hex: "FEE500"))
+                .cornerRadius(8, corners: .allCorners)
+                .padding(.horizontal)
+            }
+            .padding(.bottom, 30)
         }
         .background(Color.gray1)
-        
+    }
+}
+
+struct KakaoLogoView: View {
+    var size: CGFloat
+    
+    var body: some View {
+        Canvas { context, size in
+            let scale = size.width / 36
+            
+            let clipPath = Path { path in
+                path.addRect(CGRect(x: 0, y: 0, width: 36 * scale, height: 36 * scale))
+            }
+            
+            let logoPath = Path { path in
+                path.move(to: CGPoint(x: 18 * scale, y: 1.2 * scale))
+                path.addCurve(
+                    to: CGPoint(x: 0, y: 15.1046 * scale),
+                    control1: CGPoint(x: 8.05835 * scale, y: 1.2 * scale),
+                    control2: CGPoint(x: 0, y: 7.42593 * scale)
+                )
+                path.addCurve(
+                    to: CGPoint(x: 7.86305 * scale, y: 26.5939 * scale),
+                    control1: CGPoint(x: 0, y: 19.8801 * scale),
+                    control2: CGPoint(x: 3.11681 * scale, y: 24.09 * scale)
+                )
+                path.addLine(to: CGPoint(x: 5.86606 * scale, y: 33.889 * scale))
+                path.addCurve(
+                    to: CGPoint(x: 6.99293 * scale, y: 34.6739 * scale),
+                    control1: CGPoint(x: 5.68962 * scale, y: 34.5336 * scale),
+                    control2: CGPoint(x: 6.42683 * scale, y: 35.0474 * scale)
+                )
+                path.addLine(to: CGPoint(x: 15.7467 * scale, y: 28.8964 * scale))
+                path.addCurve(
+                    to: CGPoint(x: 18 * scale, y: 29.0093 * scale),
+                    control1: CGPoint(x: 16.4854 * scale, y: 28.9677 * scale),
+                    control2: CGPoint(x: 17.2362 * scale, y: 29.0093 * scale)
+                )
+                path.addCurve(
+                    to: CGPoint(x: 35.9999 * scale, y: 15.1046 * scale),
+                    control1: CGPoint(x: 27.9409 * scale, y: 29.0093 * scale),
+                    control2: CGPoint(x: 35.9999 * scale, y: 22.7836 * scale)
+                )
+                path.addCurve(
+                    to: CGPoint(x: 18 * scale, y: 1.2 * scale),
+                    control1: CGPoint(x: 35.9999 * scale, y: 7.42593 * scale),
+                    control2: CGPoint(x: 27.9409 * scale, y: 1.2 * scale)
+                )
+                path.closeSubpath()
+            }
+            
+            context.clip(to: clipPath)
+            context.fill(logoPath, with: .color(.black))
+        }
+        .frame(width: size, height: size)
     }
 }
 
 #Preview {
     LoginView()
+        .environmentObject(AuthViewModel())
 }

--- a/Harmony/Harmony/Views/Home/HomeView.swift
+++ b/Harmony/Harmony/Views/Home/HomeView.swift
@@ -52,7 +52,6 @@ struct HomeView: View {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button(action: {
                             authViewModel.logout()
-                            onboardingViewModel.navigationPath.removeLast(onboardingViewModel.navigationPath.count)
                         }) {
                             Image(systemName: "person.circle")
                                 .resizable()

--- a/Harmony/Harmony/Views/Onboarding/AllowNotificationView.swift
+++ b/Harmony/Harmony/Views/Onboarding/AllowNotificationView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UserNotifications
 
 struct AllowNotificationView: View {
-    @ObservedObject var viewModel: OnboardingViewModel
+    @EnvironmentObject var viewModel: OnboardingViewModel
     @State private var isNotificationEnabled = false
     @State private var isPermissionRequested = false
     

--- a/Harmony/Harmony/Views/Onboarding/CreateGroupSpaceView.swift
+++ b/Harmony/Harmony/Views/Onboarding/CreateGroupSpaceView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CreateGroupSpaceView: View {
-    @ObservedObject var viewModel: OnboardingViewModel
+    @EnvironmentObject var viewModel: OnboardingViewModel
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             

--- a/Harmony/Harmony/Views/Onboarding/EnterGroupSpaceView.swift
+++ b/Harmony/Harmony/Views/Onboarding/EnterGroupSpaceView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct EnterGroupSpaceView: View {
-    @ObservedObject var viewModel: OnboardingViewModel
+    @EnvironmentObject var viewModel: OnboardingViewModel
     var body: some View {
             VStack(alignment: .leading, spacing: 20) {
                 VStack(alignment: .leading, spacing: 8) {

--- a/Harmony/Harmony/Views/Onboarding/InputUserInfoView.swift
+++ b/Harmony/Harmony/Views/Onboarding/InputUserInfoView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct InputUserInfoView: View {
-    @ObservedObject var viewModel: OnboardingViewModel
-    
+    @EnvironmentObject var viewModel: OnboardingViewModel
+
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             VStack(alignment: .leading, spacing: 4) {
@@ -66,5 +66,5 @@ struct InputUserInfoView: View {
 }
 
 #Preview {
-    InputUserInfoView(viewModel: OnboardingViewModel())
+    InputUserInfoView()
 }

--- a/Harmony/Harmony/Views/Onboarding/InputVIPInfoView.swift
+++ b/Harmony/Harmony/Views/Onboarding/InputVIPInfoView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct InputVIPInfoView: View {
-    @ObservedObject var viewModel: OnboardingViewModel
+    @EnvironmentObject var viewModel: OnboardingViewModel
     @State private var isDropdownOpen = false
     
     let roles = ["할머니", "할아버지"]

--- a/Harmony/Harmony/Views/Onboarding/InviteVIPView.swift
+++ b/Harmony/Harmony/Views/Onboarding/InviteVIPView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct InviteVIPView: View {
-    @ObservedObject var viewModel: OnboardingViewModel
+    @EnvironmentObject var viewModel: OnboardingViewModel
     @State private var hasShared = false
     
     var body: some View {

--- a/Harmony/Harmony/Views/Onboarding/JoinGroupSpaceView.swift
+++ b/Harmony/Harmony/Views/Onboarding/JoinGroupSpaceView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct JoinGroupSpaceView: View {
-    @ObservedObject var viewModel: OnboardingViewModel
+    @EnvironmentObject var viewModel: OnboardingViewModel
     @State private var isConfirmButtonEnabled = false
     @FocusState private var isFocused: Bool
     

--- a/Harmony/Harmony/Views/Onboarding/RegisterProfileView.swift
+++ b/Harmony/Harmony/Views/Onboarding/RegisterProfileView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RegisterProfileView: View {
-    @ObservedObject var viewModel: OnboardingViewModel
+    @EnvironmentObject var viewModel: OnboardingViewModel
     @State var selectedImage: UIImage?
     @State var isImagePickerPresented: Bool = false
 


### PR DESCRIPTION
## 💡 Issue Number
- #109 
- 소셜로그인에서 받아온 토큰은 Kakao SDK에서 자체적으로 처리해줌에 따라 소셜로그인 관련 리팩토링을 진행

## 🤷‍♂️ Description
- AuthService 추가하여 소셜 로그인 관련 로직 분리
- 필요없는 모델, AuthModel 수정 
- 뷰모델 주입 방식을 @ObservedObject에서 @EnvironmentObject로 통일
- 카카오/애플 로그인 UI 개선 및 로직 정리
- baseURL을 Info.plist에서 관리하도록 변경
- 소셜 토큰 관련 UserDefaults 저장 로직 제거 (SDK에서 자체처리)


## ✳️ Remarks
- 추후 로그인 방식 저장 로직 추가 필요 (TODO 주석 참고)
- SwiftUI에서 AppDelegate를 사용하지 않는 푸시 알림 처리 방법 검토 필요